### PR TITLE
Enable unsafe setting for goldmark renderer to allow HTML tags in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 
 ## Guidelines
 - Each test should be written in Markdown
-- Tests should be compatible with Hugo v0.55
 - Each test case in a test file should be enclosed in a `<test name="test name">` tag where `name` can be any descriptive name representing the test
 - To ignore a Markdown file from testing, use *.ignore.md* as the extension instead
 - Tests also support asserting errors from `errorf`
 - The Hugo output will be generated under `<test dir>/.output`. It will be auto-cleaned.
 - Usage with test reporters is also supported. See `demo` subdirectory.
+- For Hugo 0.60+, enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup.
 
 ## Demo
 1. Checkout this repo

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 - Each test case in a test file should be enclosed in a `<test name="test name">` tag where `name` can be any descriptive name representing the test
 - To ignore a Markdown file from testing, use *.ignore.md* as the extension instead
 - Tests also support asserting errors from `errorf`
-- The Hugo output will be generated under `<test dir>/.output`. It will be auto-cleaned.
-- Usage with test reporters is also supported. See `demo` subdirectory.
-- For Hugo 0.60+, enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup.
+- The Hugo output will be generated under `<test dir>/.output`. It will be auto-cleaned
+- Usage with test reporters is also supported. See `demo` subdirectory
+- For Hugo 0.60+, enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup
 
 ## Demo
 1. Checkout this repo

--- a/demo/jest-hugo.config.json
+++ b/demo/jest-hugo.config.json
@@ -2,5 +2,12 @@
   "baseURL": "http://localhost/",
   "disableKinds": ["taxonomyTerm", "home"],
   "languageCode": "en-us",
-  "title": "Demo for Jest Hugo"
+  "title": "Demo for Jest Hugo",
+  "markup": {
+    "goldmark": {
+      "renderer": {
+        "unsafe": true
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fix #18 