### PR TITLE
Add workflow to run the demo on macOS/Windows/Ubuntu

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,34 @@
+name: Demo
+'on':
+  push:
+    branches: main
+  schedule:
+    - cron: 0 1 * * *
+  pull_request:
+  workflow_dispatch:
+jobs:
+  run:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+        hugo:
+          - 0.55.0
+          # - latest <---- Uncomment when https://github.com/manixate/jest-hugo/issues/20 is fixed
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '${{ matrix.hugo }}'
+          extended: false
+      - name: Run demo
+        run: |
+          npm install
+          cd demo
+          npm install
+          npm run jest

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,7 +1,7 @@
 name: Demo
 'on':
   push:
-    branches: main
+    branches: master
   schedule:
     - cron: 0 1 * * *
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 [![](https://img.shields.io/npm/v/jest-hugo.svg)](https://www.npmjs.com/package/jest-hugo)
 [![](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/manixate/jest-hugo/blob/master/LICENSE)
+[![](https://github.com/manixate/jest-hugo/workflows/Demo/badge.svg)](https://github.com/manixate/jest-hugo/actions/workflows/demo.yml)
 
 ## Overview
-`jest-hugo` allows you to test your Hugo theme.
+`jest-hugo` allows you to test your [Hugo](https://github.com/gohugoio/hugo) theme.
 
 Tests are written in the *tests* directory in files having the *.md* extension. [Jest](https://jestjs.io/) is used for testing. Watch mode is also supported and you don't need separate Hugo watch mode for testing.
 
 ## Requirements
 1. Jest 24+
 2. NodeJS 8+
-3. Hugo >= [0.55](https://github.com/gohugoio/hugo/releases/tag/v0.55.0)
+3. Hugo >= [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0)
 
 ## Usage
 1. Add jest-hugo and jest to your theme repo: `npm install --save jest jest-hugo`
@@ -36,25 +37,26 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 - The Hugo output is generated under `<test dir>/.output` and is auto-cleaned
 - Usage with test reporters is also supported. For that, see `demo` subdirectory.
 
+## Demo
+1. Checkout this repo
+2. Run `npm install` or `yarn install`
+3. Go to the `demo` subdirectory
+4. Run `npm install` or `yarn install`
+5. Run tests using `npm run jest` or `yarn jest`
+
+The demo was tested with Hugo [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) up to Hugo [v0.59.1](https://github.com/gohugoio/hugo/releases/tag/v0.59.1).
+
 ## Known Limitations
-- Asserting errors from `errorf` is currently only supported with Hugo <= [0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0) (see issue [#20](https://github.com/manixate/jest-hugo/issues/20)). The support for newer versions of hugo will be added later.
-- For Hugo [0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0)+, it is required to:
+- Asserting errors from `errorf` is currently only supported with Hugo <= [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0) (see issue [#20](https://github.com/manixate/jest-hugo/issues/20)). The support for newer versions of hugo will be added later.
+- For Hugo [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0)+, it is required to:
   - Enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup
   - Ensure that the test has a front matter (an empty one works too). See `demo/tests/callout.md` for example.
-- For Hugo < [0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0), tests cases should always be wrapped into a `<div />`. Example:
+- For Hugo < [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0), tests cases should always be wrapped into a `<div />`. Example:
 ```html
 <div>
   <test name="first test">{{< MyShortcode >}}</test>
   ...
 </div>
 ```
-
-## Demo
-1. Checkout this repo
-2. Go to the `demo` subdirectory
-3. Run `npm install` or `yarn install`
-4. Run tests using `npm run jest` or `yarn jest`
-
-The demo was tested with Hugo [0.55.6](https://github.com/gohugoio/hugo/releases/tag/v0.55.6)
 
 Feel free to give feedback.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 4. Run `npm install` or `yarn install`
 5. Run tests using `npm run jest` or `yarn jest`
 
-The demo was tested with Hugo [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) up to Hugo [v0.59.1](https://github.com/gohugoio/hugo/releases/tag/v0.59.1).
+The demo was tested with Hugo [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) up to Hugo [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0).
 
 ## Known Limitations
 - Asserting errors from `errorf` is currently only supported with Hugo <= [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0) (see issue [#20](https://github.com/manixate/jest-hugo/issues/20)). The support for newer versions of hugo will be added later.


### PR DESCRIPTION
* Added workflow to run the demo on macOS/Windows/Ubuntu
* Updated README.md
    * Added workflow badge
    * Added missing step to the "Demo" section
    * Moved "Known Limitations" to the end of the file

Demo of the workflow here: https://github.com/manixate/jest-hugo/pull/24/checks