### PR TITLE
Fix 3 issues

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -57,7 +57,7 @@ module.exports = async globalConfig => {
       throw error;
     } else {
       // stdout will contain errors caused by 'errorf' command prefixed by "ERROR" string
-      console.log("\x1b[32m%s\x1b[0m", "\n\nHugo build successful\n"); // green color output
+      console.log("\x1b[32m%s\x1b[0m", "\n\nHugo build successful\n", "with warning", error ); // green color output
     }
   }
 };

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -17,14 +17,19 @@ const getJestHugoConfig = rootDir => {
     customConfig = require(configPath);
   }
 
-  return merge(defaultJestConfig, customConfig, {
+  let config = merge(defaultJestConfig, {
     contentDir: ".",
     publishDir: ".output",
     resourceDir: ".output/.tmp",
     dataDir: "data",
     layoutDir: path.resolve(__dirname, "../hugo/layouts"),
     themesDir: rootDir
-  });
+  }, customConfig);
+
+  // In case the config uses relative paths
+  config.layoutDir = path.resolve(rootDir, config.layoutDir)
+  config.themesDir = path.resolve(rootDir, config.themesDir)
+  return config
 };
 
 module.exports = async globalConfig => {

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -33,6 +33,15 @@ function findHugoTestOutputPath(testPath, hugoContentDir, hugoOutputDir) {
 }
 
 /**
+ * Return the "{folder}/{file}.md" part.
+ */
+function extractPathFromErrorf(output) {
+  var regexp = /(.*).md:/
+  var matches = regexp.exec(output)
+  return (matches && matches.length > 0) ? matches[1] : ""
+}
+
+/**
  * Generate test cases from the test file
  * 
  * @param {string} testPath Path of the test file
@@ -54,8 +63,11 @@ function generateTestCases(testPath) {
   // Create test cases
   const generatedTestCases = []
   for (key in testCases) {
+
+    // Normalize file paths in errors ("{folder}\{file}.md: ..." => "{folder}/{file}.md: ...")
+    const filepath = extractPathFromErrorf(testCases[key])
     const value = testCases[key]
-      .replace(/\\/g, '/') // Normalize file paths in errors ("folder\\file.md: ..." => "folder/file.md: ...")
+      .replace(filepath, filepath.replace(/\\/g, '/'))
       .replace(/[^\\]'/g, '\\\'')
       .replace(/\r\n/g, '\\n') // CRLF on Windows with Hugo 0.60+
       .replace(/\n/g, '\\n');


### PR DESCRIPTION
This PR fixes the following:
* Issue 1: all backslashes are currently being replaced by slashes when attempting to normalize paths in errorf messages ("_Fixed an issue with "\\" being replaced in the entire content_")
* Issue 2: some values from the provided "jest-hugo.config.json" are being replaced with default values ("_Fixed an issue with configuration keys being overridden_")
* Issue 3: the project as it is doesn't work if the provided "jest-hugo.config.json" contains relative paths ("_Added support for relative `layoutDir` and `themesDir` paths_")