### PR TITLE
Fix issue #20 / support for errorf assertions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,16 +1,16 @@
 name: Demo
-'on':
+"on":
   push:
-    branches: 
-      - master
-      - feature/**
+    branches:
+      - "**"
   schedule:
     - cron: 0 1 * * *
   pull_request:
   workflow_dispatch:
 jobs:
   run:
-    runs-on: '${{ matrix.os }}'
+    runs-on: "${{ matrix.os }}"
+    # continue-on-error: true
     strategy:
       matrix:
         os:
@@ -18,16 +18,15 @@ jobs:
           - windows-latest
           - macos-latest
         hugo:
-          - 0.55.0
-          - 0.61.0
-          # - latest <---- Uncomment when https://github.com/manixate/jest-hugo/issues/20 is fixed
+          - 0.62.0
+          - latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '${{ matrix.hugo }}'
+          hugo-version: "${{ matrix.hugo }}"
           extended: false
       - name: Run demo
         run: |

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,19 @@
+"on":
+  push:
+    branches:
+      - "**"
+  schedule:
+    - cron: 0 1 * * *
+name: Broken links?
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Link Checker
+        id: la
+        uses: lycheeverse/lychee-action@v1.1.1
+        with:
+          args: --verbose --no-progress **/*.md
+      - name: Fail?
+        run: "exit ${{ steps.la.outputs.exit_code }}"

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,17 @@
+name: Prettier
+"on":
+  push:
+    branches:
+      - "**"
+  pull_request:
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run prettier
+        run: |
+          yarn install
+          yarn prettier --check .

--- a/.github/workflows/yarn-publish.yml
+++ b/.github/workflows/yarn-publish.yml
@@ -5,7 +5,7 @@ name: Publish
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   publish-npm:
@@ -20,3 +20,19 @@ jobs:
       - run: yarn publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  publish-gpr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com/
+      - run: yarn
+      - run: yarn publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+*.html
+*.json
+*.xml

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "trailingComma": "none",
+  "printWidth": 140
+}

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Write each test case enclosed in a `<test name="test name">` tag where `name` ca
 
 ```
 <test name="should render successfully">
-  {{% MyShortCode %}}
+  {{% myshortcode %}}
   ...
-  {{% /MyShortCode %}}
+  {{% /myshortcode %}}
 </test>
 ```
 
@@ -55,9 +55,9 @@ This project allows asserting errors from [`errorf`](https://gohugo.io/functions
 ```
 <test name="should throw an error when invalid type is provided">
   {{< expect error="Invalid type!" >}}
-  {{% MyShortCode type="invalid" %}}
+  {{% myshortcode type="invalid" %}}
   ...
-  {{% /MyShortCode %}}
+  {{% /myshortcode %}}
 </test>
 ```
 
@@ -98,6 +98,6 @@ The demo was tested with Hugo [v0.62.0](https://github.com/gohugoio/hugo/release
 - This project requires to enable `unsafe: true` for the Goldmark renderer. See: [`markup.goldmark.renderer`](https://gohugo.io/getting-started/configuration-markup).
 - Ensure that each test file has a front matter (an empty one works too). See [`callout.md`](./demo/tests/shortcodes/callout.md?plain=1) for example.
 - This project leverages the [`warnf`](https://gohugo.io/functions/errorf/) template func introduced with Hugo [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.62.0). For that reason, versions of Hugo before 0.62.0 aren't supported anymore.
-- Hugo currently doesn't log multiple times the same error. Test cases asserting an exact same error message is thrown under multiple conditions must be defined in their own _.md_ file (see [`demo/tests/shortcodes`](./demo/tests/shortcodes) subdirectory).
+- One single log message is created for multiple calls to [`errorf`](https://gohugo.io/functions/errorf/) with the exact same string. This means a single test file can't output multiple times the same error, and test cases expecting an exact same error message must be defined in their own _.md_ file (see [`demo/tests/shortcodes`](./demo/tests/shortcodes) subdirectory) (see also: [#20](https://github.com/manixate/jest-hugo/issues/20)).
 
 Feel free to give feedback.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,22 @@
 [![](https://img.shields.io/npm/v/jest-hugo.svg)](https://www.npmjs.com/package/jest-hugo)
 [![](https://img.shields.io/badge/license-MIT-yellow.svg)](https://github.com/manixate/jest-hugo/blob/master/LICENSE)
 [![](https://github.com/manixate/jest-hugo/workflows/Demo/badge.svg)](https://github.com/manixate/jest-hugo/actions/workflows/demo.yml)
+[![](https://github.com/manixate/jest-hugo/workflows/Prettier/badge.svg)](https://github.com/manixate/jest-hugo/actions/workflows/prettier.yml)
 
 ## Overview
+
 `jest-hugo` allows you to test your [Hugo](https://github.com/gohugoio/hugo) theme.
 
-Tests are written in the *tests* directory in files having the *.md* extension. [Jest](https://jestjs.io/) is used for testing. Watch mode is also supported and you don't need separate Hugo watch mode for testing.
+Tests are written in the _tests_ directory in files having the _.md_ extension. [Jest](https://jestjs.io/) is used for testing. Watch mode is also supported and you don't need separate Hugo watch mode for testing.
 
 ## Requirements
+
 1. Jest 24+
 2. NodeJS 8+
 3. Hugo >= [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0)
 
 ## Usage
+
 1. Add jest-hugo and jest to your theme repo: `npm install --save jest jest-hugo`
 2. Create a `tests` subdirectory and a `first-test.md` file under it
 3. Write tests using the `<test name='first test'>{{< MyShortcode >}}</test>` convention
@@ -25,19 +29,22 @@ Tests are written in the *tests* directory in files having the *.md* extension. 
 For watch mode, just use `jest --watchAll` which will rerun tests whenever there is an update.
 
 ## Configuration
+
 - You can provide your own Hugo config by adding a `jest-hugo.config.json`
 - If you need to change the test output directory, you can provide a path in `JEST_HUGO_TEST_DIR` environment variable
 - You can specify path to your `hugo` executable by setting `JEST_HUGO_EXECUTABLE` environment variable. By default it uses the one in environment path.
 
 ## Guidelines
+
 - Each test should be written in Markdown
 - Each test case in a test file should be enclosed in a `<test name="test name">` tag where `name` can be any descriptive name representing the test
-- To exclude a Markdown file from testing, use *.ignore.md* as the extension instead
+- To exclude a Markdown file from testing, use _.ignore.md_ as the extension instead
 - Tests also support asserting errors from `errorf`
 - The Hugo output is generated under `<test dir>/.output` and is auto-cleaned
 - Usage with test reporters is also supported. For that, see `demo` subdirectory.
 
 ## Demo
+
 1. Checkout this repo
 2. Run `npm install` or `yarn install`
 3. Go to the `demo` subdirectory
@@ -47,11 +54,13 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 The demo was tested with Hugo [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) up to Hugo [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0).
 
 ## Known Limitations
+
 - Asserting errors from `errorf` is currently only supported with Hugo <= [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0) (see issue [#20](https://github.com/manixate/jest-hugo/issues/20)). The support for newer versions of hugo will be added later.
 - For Hugo [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0)+, it is required to:
   - Enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup
   - Ensure that the test has a front matter (an empty one works too). See `demo/tests/callout.md` for example.
 - For Hugo < [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0), tests cases should always be wrapped into a `<div />`. Example:
+
 ```html
 <div>
   <test name="first test">{{< MyShortcode >}}</test>

--- a/README.md
+++ b/README.md
@@ -9,39 +9,79 @@
 
 `jest-hugo` allows you to test your [Hugo](https://github.com/gohugoio/hugo) theme.
 
-Tests are written in the _tests_ directory in files having the _.md_ extension. [Jest](https://jestjs.io/) is used for testing. Watch mode is also supported and you don't need separate Hugo watch mode for testing.
+Tests are written in a _tests_ directory in files having the _.md_ extension.
+[Jest](https://jestjs.io/) is used for testing. The Jest watch mode is also supported (no need for Hugo in watch mode).
 
 ## Requirements
 
 1. Jest 24+
 2. NodeJS 8+
-3. Hugo >= [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0)
+3. Hugo >= [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.62.0)
 
 ## Usage
 
-1. Add jest-hugo and jest to your theme repo: `npm install --save jest jest-hugo`
-2. Create a `tests` subdirectory and a `first-test.md` file under it
-3. Write tests using the `<test name='first test'>{{< MyShortcode >}}</test>` convention
-4. Run tests using `npm run jest`
-5. A snapshot subdirectory will be created at the same level as your test file
-6. Update snapshots with `jest -u`
+### Adding Dependencies
 
-For watch mode, just use `jest --watchAll` which will rerun tests whenever there is an update.
+Add `jest-hugo` and `jest` packages to your theme repo: `npm install --save jest jest-hugo`
+
+### Writing Tests
+
+#### Guidelines
+
+- Create a `tests` subdirectory with `.md` files under it
+- Each test must be written in Markdown
+- The Hugo output is generated under `<test dir>/.output` and is auto-cleaned before each run
+- To exclude a Markdown file from testing, use _.ignore.md_ as file extension (instead of _.md_)
+- Usage with test reporters is also supported. For that, refer to the [`demo`](./demo) subdirectory.
+
+#### Nominal Cases ✔️
+
+Write each test case enclosed in a `<test name="test name">` tag where `name` can be any descriptive name representing the test. Example:
+
+```
+<test name="should render successfully">
+  {{% MyShortCode %}}
+  ...
+  {{% /MyShortCode %}}
+</test>
+```
+
+When running the tests, a Jest `__snapshots__` subdirectory will be created at the same level as your test file.
+
+#### Error Cases ❌
+
+This project allows asserting errors from [`errorf`](https://gohugo.io/functions/errorf/). For that, use the `expect` keyword the following way:
+
+```
+<test name="should throw an error when invalid type is provided">
+  {{< expect error="Invalid type!" >}}
+  {{% MyShortCode type="invalid" %}}
+  ...
+  {{% /MyShortCode %}}
+</test>
+```
+
+When running the tests, _ERROR YYYY/MM/DD HH:MM:SS shortcodes\\myshortcode.md: Invalid type!_ will be expected to be found in the Hugo output.
+
+### Running Tests
+
+1. Run tests using `npm run jest`
+2. Update Jest snapshots with `jest -u`
+3. For watch mode, use `jest --watchAll` which will rerun tests whenever there is an update.
 
 ## Configuration
 
-- You can provide your own Hugo config by adding a `jest-hugo.config.json`
-- If you need to change the test output directory, you can provide a path in `JEST_HUGO_TEST_DIR` environment variable
-- You can specify path to your `hugo` executable by setting `JEST_HUGO_EXECUTABLE` environment variable. By default it uses the one in environment path.
+### Hugo Configuration
 
-## Guidelines
+You can provide your own Hugo config by creating a `jest-hugo.config.json` file at the root of your project.
 
-- Each test should be written in Markdown
-- Each test case in a test file should be enclosed in a `<test name="test name">` tag where `name` can be any descriptive name representing the test
-- To exclude a Markdown file from testing, use _.ignore.md_ as the extension instead
-- Tests also support asserting errors from `errorf`
-- The Hugo output is generated under `<test dir>/.output` and is auto-cleaned
-- Usage with test reporters is also supported. For that, see `demo` subdirectory.
+### Environment Variables
+
+| Variable               | Description                | Default |
+| ---------------------- | -------------------------- | ------- |
+| `JEST_HUGO_TEST_DIR`   | Name of the test directory | "tests" |
+| `JEST_HUGO_EXECUTABLE` | Name of the Hugo command   | "hugo"  |
+| `JEST_HUGO_DEBUG`      | Output additional logs     | false   |
 
 ## Demo
 
@@ -51,21 +91,13 @@ For watch mode, just use `jest --watchAll` which will rerun tests whenever there
 4. Run `npm install` or `yarn install`
 5. Run tests using `npm run jest` or `yarn jest`
 
-The demo was tested with Hugo [v0.55.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) up to Hugo [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0).
+The demo was tested with Hugo [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) and the [latest](https://github.com/gohugoio/hugo/releases/latest) version.
 
 ## Known Limitations
 
-- Asserting errors from `errorf` is currently only supported with Hugo <= [v0.61.0](https://github.com/gohugoio/hugo/releases/tag/v0.61.0) (see issue [#20](https://github.com/manixate/jest-hugo/issues/20)). The support for newer versions of hugo will be added later.
-- For Hugo [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0)+, it is required to:
-  - Enable `unsafe: true` for goldmark renderer `markup.goldmark.renderer` https://gohugo.io/getting-started/configuration-markup
-  - Ensure that the test has a front matter (an empty one works too). See `demo/tests/callout.md` for example.
-- For Hugo < [v0.60.0](https://github.com/gohugoio/hugo/releases/tag/v0.60.0), tests cases should always be wrapped into a `<div />`. Example:
-
-```html
-<div>
-  <test name="first test">{{< MyShortcode >}}</test>
-  ...
-</div>
-```
+- This project requires to enable `unsafe: true` for the Goldmark renderer. See: [`markup.goldmark.renderer`](https://gohugo.io/getting-started/configuration-markup).
+- Ensure that each test file has a front matter (an empty one works too). See [`callout.md`](./demo/tests/shortcodes/callout.md?plain=1) for example.
+- This project leverages the [`warnf`](https://gohugo.io/functions/errorf/) template func introduced with Hugo [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.62.0). For that reason, versions of Hugo before 0.62.0 aren't supported anymore.
+- Hugo currently doesn't log multiple times the same error. Test cases asserting an exact same error message is thrown under multiple conditions must be defined in their own _.md_ file (see [`demo/tests/shortcodes`](./demo/tests/shortcodes) subdirectory).
 
 Feel free to give feedback.

--- a/demo/jest-hugo.config.json
+++ b/demo/jest-hugo.config.json
@@ -1,6 +1,6 @@
 {
   "baseURL": "http://localhost/",
-  "disableKinds": ["taxonomyTerm", "home"],
+  "disableKinds": ["taxonomyTerm", "home", "sitemap"],
   "languageCode": "en-us",
   "title": "Demo for Jest Hugo",
   "markup": {

--- a/demo/jest.config.js
+++ b/demo/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: "jest-hugo",
-  reporters: [ "default", "jest-junit" ]
-};
+  reporters: ["default", "jest-junit"]
+}

--- a/demo/tests/shortcodes/__snapshots__/callout.md.snap
+++ b/demo/tests/shortcodes/__snapshots__/callout.md.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`callout should render successful with alert 1`] = `
+exports[`callout should render successfully with alert 1`] = `
 <div>
   <div class="callout callout-alert"
     role="callout">
@@ -11,7 +11,7 @@ exports[`callout should render successful with alert 1`] = `
 </div>
 `;
 
-exports[`callout should render successful with warning 1`] = `
+exports[`callout should render successfully with warning 1`] = `
 <div>
   <div class="callout callout-warning"
     role="callout">
@@ -19,17 +19,5 @@ exports[`callout should render successful with warning 1`] = `
     </div>
     <div class="callout-content">An warning type callout</div>
   </div>
-</div>
-`;
-
-exports[`callout should show error when enter invalid type. 1`] = `
-<div>
-  shortcodes/callout.md: Invalid callout&#39;s type &#39;invalid&#39;. Expecting one of &#39;alert warning&#39;
-</div>
-`;
-
-exports[`callout should show error when missing type parameter. 1`] = `
-<div>
-  shortcodes/callout.md: Invalid callout&#39;s type &#39;%!s(&lt;nil&gt;)&#39;. Expecting one of &#39;alert warning&#39;
 </div>
 `;

--- a/demo/tests/shortcodes/callout-same-error.md
+++ b/demo/tests/shortcodes/callout-same-error.md
@@ -1,0 +1,9 @@
+---
+---
+
+<test name="should throw error when invalid type">
+  {{< expect error="Invalid callout's type 'invalid'. Expecting one of 'alert warning'" >}}
+  {{% callout type="invalid" %}}
+  Something
+  {{% /callout %}}
+</test>

--- a/demo/tests/shortcodes/callout.md
+++ b/demo/tests/shortcodes/callout.md
@@ -1,27 +1,28 @@
 ---
 ---
-<div> <!-- Only needed with Hugo < v0.60.0 -->
-  <test name="should render successful with alert">
+
+<test name="should render successfully with alert">
   {{% callout type="alert" %}}
   An alert type callout
   {{% /callout %}}
-  </test>
+</test>
 
-  <test name="should render successful with warning">
+<test name="should render successfully with warning">
   {{% callout type="warning" %}}
   An warning type callout
   {{% /callout %}}
-  </test>
+</test>
 
-  <test name="should show error when missing type parameter.">
+<test name="should throw error when missing type parameter">
+  {{< expect error="Invalid callout's type '%!s(<nil>)'. Expecting one of 'alert warning'" >}}
   {{% callout %}}
-  An note type callout
+  Something
   {{% /callout %}}
-  </test>
+</test>
 
-  <test name="should show error when enter invalid type.">
+<test name="should throw error when invalid type">
+  {{< expect error="Invalid callout's type 'invalid'. Expecting one of 'alert warning'" >}}
   {{% callout type="invalid" %}}
-  An note type callout
+  Something
   {{% /callout %}}
-  </test>
-</div>
+</test>

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -749,6 +749,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -833,6 +838,30 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
+cheerio@^1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 ci-info@^3.2.0:
   version "3.2.0"
@@ -928,6 +957,22 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
+css-what@^5.0.0, css-what@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
 cssom@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.4.4.tgz#5a66cf93d2d0b661d80bf6a44fb65f5c2e4e0a10"
@@ -996,12 +1041,42 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
 domexception@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-2.0.1.tgz#fb44aefba793e1574b0af6aed2801d057529f304"
   integrity sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
   dependencies:
     webidl-conversions "^5.0.0"
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2, domutils@^2.6.0, domutils@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
 editorconfig@^0.15.3:
   version "0.15.3"
@@ -1027,6 +1102,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1228,6 +1308,16 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 http-proxy-agent@^4.0.1:
   version "4.0.1"
@@ -1541,11 +1631,11 @@ jest-haste-map@^27.3.1:
     fsevents "^2.3.2"
 
 "jest-hugo@file:..":
-  version "1.0.3"
+  version "1.0.5"
   dependencies:
+    cheerio "^1.0.0-rc.10"
     js-beautify "1.14.0"
     lodash.merge "4.6.2"
-    lodash.unescape "4.0.1"
     tmp "0.2.1"
 
 jest-jasmine2@^27.3.1:
@@ -1909,11 +1999,6 @@ lodash.merge@4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-
 lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -2039,6 +2124,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+nth-check@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
+
 nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
@@ -2089,7 +2181,14 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-parse5@6.0.1:
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@6.0.1, parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
@@ -2453,6 +2552,11 @@ tr46@^2.1.0:
   integrity sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==
   dependencies:
     punycode "^2.1.1"
+
+tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 type-check@~0.3.2:
   version "0.3.2"

--- a/hugo/layouts/shortcodes/expect.html
+++ b/hugo/layouts/shortcodes/expect.html
@@ -1,0 +1,8 @@
+{{ $error := (.Get "error") }}
+
+{{/* Compute a unique id for the assertion  */}}
+{{ $seed := printf "%s" .Page.File.Path | printf "%d %s" now.Nanosecond | printf "%s" }}
+{{ $internal_id := delimit (shuffle (split (md5 $seed) "" )) "" }}
+
+{{- warnf "%s: 'jest-expected-error' %s|%s" .Page.File.Path $internal_id $error }}
+<div id="expected-error" data-id="{{ $internal_id }}" data-error="{{ $error }}" />

--- a/jest-hugo.config.json
+++ b/jest-hugo.config.json
@@ -2,5 +2,5 @@
   "baseURL": "http://localhost/",
   "title": "Theme Tests",
   "theme": "",
-  "ignoreFiles": [ "\\.snap" ]
+  "ignoreFiles": ["\\.snap"]
 }

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -1,14 +1,10 @@
-const testDir = process.env.JEST_HUGO_TEST_DIR;
+const testDir = process.env.JEST_HUGO_TEST_DIR
 
 module.exports = {
   transform: {
     "\\.md$": require.resolve("./jest/transform.js")
   },
-  moduleFileExtensions: [
-    "js",
-    "md",
-    "html"
-  ],
+  moduleFileExtensions: ["js", "md", "html"],
   testMatch: [`**/${testDir || "tests"}/**/!(*.ignore).md`],
   snapshotSerializers: [require.resolve("./jest/serializer.js")],
   noStackTrace: true,

--- a/jest/serializer.js
+++ b/jest/serializer.js
@@ -1,15 +1,15 @@
-const beautify = require('js-beautify').html;
+const beautify = require("js-beautify").html
 
 module.exports = {
   print(val, serialize, indent) {
-    if (val.custom == 'beautify') {
-      return beautify(val.input, { wrap_attributes: 'force', indent_size: 2 });
+    if (val.custom == "beautify") {
+      return beautify(val.input, { wrap_attributes: "force", indent_size: 2 })
     } else {
-      return serialize(val.input);
+      return serialize(val.input)
     }
   },
 
   test(val) {
-    return !!val.custom;
-  },
+    return !!val.custom
+  }
 }

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,68 +1,135 @@
-const childProcess = require("child_process");
-const path = require("path");
-const fs = require("fs");
-const merge = require("lodash.merge");
-const tmp = require("tmp");
-tmp.setGracefulCleanup();
+const childProcess = require("child_process")
+const path = require("path")
+const fs = require("fs")
+const merge = require("lodash.merge")
+const tmp = require("tmp")
+tmp.setGracefulCleanup()
 
-const defaultJestConfig = require("../jest-hugo.config.json");
-const defaultJestHugoTestDir = "tests";
-const defaultJestHugoExecutable = "hugo";
+const defaultJestConfig = require("../jest-hugo.config.json")
+const defaultJestHugoTestDir = "tests"
+const defaultJestHugoExecutable = "hugo"
+const debug = process.env.JEST_HUGO_DEBUG || false
 
-const getJestHugoConfig = rootDir => {
-  const configPath = path.resolve(rootDir, "jest-hugo.config.json");
-  const configExists = fs.existsSync(configPath);
-  let customConfig = null;
+const getJestHugoConfig = (rootDir) => {
+  const configPath = path.resolve(rootDir, "jest-hugo.config.json")
+  const configExists = fs.existsSync(configPath)
+  let customConfig = null
   if (configExists) {
-    customConfig = require(configPath);
+    customConfig = require(configPath)
   }
 
-  let config = merge(defaultJestConfig, {
-    contentDir: ".",
-    publishDir: ".output",
-    resourceDir: ".output/.tmp",
-    dataDir: "data",
-    layoutDir: path.resolve(__dirname, "../hugo/layouts"),
-    themesDir: rootDir
-  }, customConfig);
+  let config = merge(
+    defaultJestConfig,
+    {
+      contentDir: ".",
+      publishDir: ".output",
+      resourceDir: ".output/.tmp",
+      dataDir: "data",
+      layoutDir: path.resolve(__dirname, "../hugo/layouts"),
+      themesDir: rootDir
+    },
+    customConfig
+  )
 
   // In case the config uses relative paths
   config.layoutDir = path.resolve(rootDir, config.layoutDir)
   config.themesDir = path.resolve(rootDir, config.themesDir)
   return config
-};
+}
 
-module.exports = async globalConfig => {
-  const jestHugoConfig = getJestHugoConfig(globalConfig.rootDir);
+const extractInfoFromLog = (logLine) => {
+  // Each log line is of format:
+  // <level> <YYYY/MM/DD> <HH:MM:SS> <filename>: <log line>
+  // Example:
+  // ERROR 2021/09/23 13:08:34 shortcodes/file.md: Error here
+  const logSplit = logLine.split(" ")
+  const level = logSplit[0]
+  const filename = logSplit[3].replace(":", "")
+  const log = logSplit.slice(4).join(" ")
 
-  const testDir = path.resolve(
-    globalConfig.rootDir,
-    process.env.JEST_HUGO_TEST_DIR || defaultJestHugoTestDir
-  );
+  return {
+    level: level,
+    filename: filename,
+    log: log
+  }
+}
 
-  process.env.JEST_HUGO_CONTENT_DIR = path.resolve(testDir, jestHugoConfig.contentDir);
-  process.env.JEST_HUGO_OUTPUT_DIR = path.resolve(testDir, jestHugoConfig.publishDir);
-  
+module.exports = async (globalConfig) => {
+  const jestHugoConfig = getJestHugoConfig(globalConfig.rootDir)
+
+  const testDir = path.resolve(globalConfig.rootDir, process.env.JEST_HUGO_TEST_DIR || defaultJestHugoTestDir)
+
+  const outputDir = path.resolve(testDir, jestHugoConfig.publishDir)
+  process.env.JEST_HUGO_CONTENT_DIR = path.resolve(testDir, jestHugoConfig.contentDir)
+  process.env.JEST_HUGO_OUTPUT_DIR = outputDir
+
   try {
-    // Create temporary hugo config json file. It will be cleaned up automatically.
-    const hugoConfigFile = tmp.fileSync({ postfix: ".json" });
-    fs.writeFileSync(hugoConfigFile.name, JSON.stringify(jestHugoConfig));
+    // Delete the previous ".output" dir
+    fs.rmSync(outputDir, { recursive: true, force: true })
 
-    const hugoExecutable = process.env.JEST_HUGO_EXECUTABLE || defaultJestHugoExecutable;
+    // Create a temporary hugo config json file. It will be cleaned up automatically.
+    const hugoConfigFile = tmp.fileSync({ postfix: ".json" })
+    fs.writeFileSync(hugoConfigFile.name, JSON.stringify(jestHugoConfig))
 
+    // Run Hugo
+    const hugoExecutable = process.env.JEST_HUGO_EXECUTABLE || defaultJestHugoExecutable
     await childProcess.execFileSync(hugoExecutable, ["--config", hugoConfigFile.name], {
       stdio: ["pipe", "pipe", "pipe"],
       encoding: "utf8",
       cwd: testDir
-    });
+    })
   } catch (error) {
     if (error.stderr && !error.stdout.includes("ERROR")) {
       // stderr represent errors
       // stdout will not have "ERROR" string if the errors are during build process e.g parsing failed.
-      throw error;
-    } else {
-      // stdout will contain errors caused by 'errorf' command prefixed by "ERROR" string
-      console.log("\x1b[32m%s\x1b[0m", "\n\nHugo build successful\n", "with warning", error ); // green color output
+      throw error
+    }
+
+    // Parse stdout that contains errors caused by 'errorf' prefixed by "ERROR" or "WARN"
+    const groupedLogByFilename = error.stdout
+      .replace("Building sites … ", "")
+      .replace("Start building sites … ", "")
+      .split("\n")
+      .filter((s) => (s.startsWith("WARN") && s.indexOf("'jest-expected-error") >= 0) || s.startsWith("ERROR"))
+      .reduce((map, log) => {
+        const logDetail = extractInfoFromLog(log.replace(/\s'jest-expected-error'\s/gi, " "))
+        if (map[logDetail.filename]) {
+          map[logDetail.filename].push({
+            level: logDetail.level,
+            log: logDetail.log
+          })
+        } else {
+          map[logDetail.filename] = [{ level: logDetail.level, log: logDetail.log }]
+        }
+        return map
+      }, {})
+    const output = {}
+    Object.entries(groupedLogByFilename).forEach(([key, detail]) => {
+      const expectedErrorGroups = []
+      for (let index = 0; index < detail.length; index++) {
+        const logDetail = detail[index]
+        const group = {
+          expected: null,
+          actual: null
+        }
+        if (logDetail.level === "WARN") {
+          group.expected = logDetail.log
+          if (index < detail.length - 1 && detail[index + 1].level === "ERROR") {
+            group.actual = detail[index + 1].log
+            index++
+          }
+
+          expectedErrorGroups.push(group)
+        }
+      }
+
+      output[key] = expectedErrorGroups
+    })
+
+    fs.writeFileSync(path.resolve(outputDir, "output.err.json"), JSON.stringify(output, null, 2))
+
+    if (debug) {
+      console.log("\x1b[32m%s\x1b[0m", "\n\nHugo build successful\n", "with warning", error) // green color output
     }
   }
-};
+}

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -1,97 +1,94 @@
-const path = require('path');
-const fs = require('fs');
-const crypto = require('crypto');
-
-/*
-  Regex representing a test case
-  <test name="test name">
-    <!-- Test case here -->
-  </test>
-*/
-const regex = new RegExp(/<test.*?name="([^"]*?)".*?>((?:.*?\r?\n?)*?)<\/test>/gi);
+const path = require("path")
+const fs = require("fs")
+const crypto = require("crypto")
+const cheerio = require("cheerio")
 
 /**
  * Returns the path to index.html output file related to the test file
- * 
+ *
  * If the test is inside <test>/xyz/_index.md then the test output will be in <output>/xyz/index.html
- * If the test is inside <test>/xyz/abc.md then the test output will be in <output>/xyz/abc/index.html  
- * 
+ * If the test is inside <test>/xyz/abc.md then the test output will be in <output>/xyz/abc/index.html
+ *
  * @param {string} testPath Path of the test file
  * @param {string} hugoContentDir Path of hugo content directory.
  * @param {string} hugoOutputDir Path of hugo output directory.
- * 
+ *
  * @returns {string} Path of the index.html file
  */
 function findHugoTestOutputPath(testPath, hugoContentDir, hugoOutputDir) {
-  const testDirectory = path.parse(path.relative(hugoContentDir, testPath));
+  const testDirectory = path.parse(path.relative(hugoContentDir, testPath))
 
   if (testDirectory.base === "_index.md") {
-    return path.resolve(hugoOutputDir, testDirectory.dir, 'index.html');
+    return path.resolve(hugoOutputDir, testDirectory.dir, "index.html")
   } else {
-    return path.resolve(hugoOutputDir, testDirectory.dir, testDirectory.name, 'index.html');
+    return path.resolve(hugoOutputDir, testDirectory.dir, testDirectory.name, "index.html")
   }
-}
-
-/**
- * Return the "{folder}/{file}.md" part.
- */
-function extractPathFromErrorf(output) {
-  var regexp = /(.*).md:/
-  var matches = regexp.exec(output)
-  return (matches && matches.length > 0) ? matches[1] : ""
 }
 
 /**
  * Generate test cases from the test file
- * 
+ *
+ * @param
  * @param {string} testPath Path of the test file
- * 
+ *
  * @returns {string} Generated test case string
  */
-function generateTestCases(testPath) {
-  const fileData = fs.readFileSync(testPath, "utf-8");
+function generateTestCases(testPath, errors) {
+  const fileData = fs.readFileSync(testPath, "utf-8")
 
-  const testCases = {};
-  var match;
-  do {
-    match = regex.exec(fileData);
-    if (match) {
-      testCases[match[1]] = match[2];
-    }
-  } while (match);
-
-  // Create test cases
-  const generatedTestCases = []
-  for (key in testCases) {
-
-    // Normalize file paths in errors ("{folder}\{file}.md: ..." => "{folder}/{file}.md: ...")
-    const filepath = extractPathFromErrorf(testCases[key])
-    const value = testCases[key]
-      .replace(filepath, filepath.replace(/\\/g, '/'))
-      .replace(/[^\\]'/g, '\\\'')
-      .replace(/\r\n/g, '\\n') // CRLF on Windows with Hugo 0.60+
-      .replace(/\n/g, '\\n');
-
-    var testTitle = key.replace(/[^\\]'/g, '\\\'')
-
-    generatedTestCases.push([
-      `it ('${testTitle}', () => {`,
-      `  const value = '${value}';`,
-      "  expect({custom: 'beautify', input: value}).toMatchSnapshot();",
-      "})"
-    ].join("\n"));
+  const $ = cheerio.load(fileData, null, false)
+  const tests = $("test")
+  if (tests.length === 0) {
+    return []
   }
 
-  return generatedTestCases;
+  const generatedTestCases = tests
+    .map((i, test) => {
+      const testTitle = test.attribs.name
+      const value = $(test)
+        .html()
+        .replace(/[^\\]'/g, "\\'")
+        .replace(/\r\n/g, "\\n") // CRLF on Windows with Hugo 0.60+
+        .replace(/\n/g, "\\n")
+
+      // Test for asserting on errors
+      const expectedError = $("div#expected-error", test)
+      if (expectedError.length > 0) {
+        const errorId = expectedError.attr("data-id")
+        const errorText = expectedError.attr("data-error")
+        // Pick the corresponding error from the logs
+        const error = (errors.find((e) => e.expected.startsWith(`${errorId}|`)) || {}).actual.replace(/'/g, "\\'")
+
+        const expected = errorText.replace(/'/g, "\\'")
+
+        return [
+          `it ('${testTitle}', () => {`,
+          `  const actual = '${error}';`,
+          `  const expected = '${expected}';`,
+          `  expect(actual).toEqual(expected);`,
+          "})"
+        ].join("\n")
+      } else {
+        return [
+          `it ('${testTitle}', () => {`,
+          `  const value = '${value}';`,
+          "  expect({custom: 'beautify', input: value}).toMatchSnapshot();",
+          "})"
+        ].join("\n")
+      }
+    })
+    .get()
+
+  return generatedTestCases
 }
 
 module.exports = {
   getCacheKey: (source, filepath, configString) => {
-    const jestHugoOutputDir = process.env.JEST_HUGO_OUTPUT_DIR;
-    const jestHugoContentDir = process.env.JEST_HUGO_CONTENT_DIR;
+    const jestHugoOutputDir = process.env.JEST_HUGO_OUTPUT_DIR
+    const jestHugoContentDir = process.env.JEST_HUGO_CONTENT_DIR
 
     const hugoTestPath = findHugoTestOutputPath(filepath, jestHugoContentDir, jestHugoOutputDir)
-    const testFileData = fs.readFileSync(hugoTestPath, "utf-8");
+    const testFileData = fs.readFileSync(hugoTestPath, "utf-8")
 
     return crypto
       .createHash("md5")
@@ -105,21 +102,25 @@ module.exports = {
       .update("\0", "utf8")
       .update(JSON.stringify(configString))
       .update("\0", "utf8")
-      .digest("hex");
+      .digest("hex")
   },
-  process: function(source, filepath) {
-    const jestHugoOutputDir = process.env.JEST_HUGO_OUTPUT_DIR;
-    const jestHugoContentDir = process.env.JEST_HUGO_CONTENT_DIR;
+  process: function (source, filepath) {
+    const jestHugoOutputDir = process.env.JEST_HUGO_OUTPUT_DIR
+    const jestHugoContentDir = process.env.JEST_HUGO_CONTENT_DIR
 
     const hugoTestPath = findHugoTestOutputPath(filepath, jestHugoContentDir, jestHugoOutputDir)
-    const testName = path.basename(path.dirname(hugoTestPath));
+    const testName = path.basename(path.dirname(hugoTestPath))
 
-    const testCases = generateTestCases(hugoTestPath);
-    const code = [
-      `describe('${testName}', () => {`,
-      testCases.join("\n\n"),
-      "})"
-    ].join("\n");
+    var errors = null
+    const errorFile = path.resolve(jestHugoOutputDir, "output.err.json")
+    if (fs.existsSync(errorFile)) {
+      errors = JSON.parse(fs.readFileSync(errorFile))
+    }
+
+    const relativeFilePath = path.relative(jestHugoContentDir, filepath)
+
+    const testCases = generateTestCases(hugoTestPath, errors[relativeFilePath])
+    const code = [`describe('${testName}', () => {`, testCases.join("\n\n"), "})"].join("\n")
 
     return {
       code

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/manixate/jest-hugo#readme",
   "dependencies": {
     "cheerio": "^1.0.0-rc.10",
+    "fs-extra": "^10.0.0",
     "js-beautify": "1.14.0",
     "lodash.merge": "4.6.2",
     "tmp": "0.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-hugo",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Test your hugo theme including shortcodes using Jest",
   "main": "jest-preset.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Test your hugo theme including shortcodes using Jest",
   "main": "jest-preset.js",
   "scripts": {
+    "format": "prettier --write .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -21,9 +22,12 @@
   },
   "homepage": "https://github.com/manixate/jest-hugo#readme",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.10",
     "js-beautify": "1.14.0",
     "lodash.merge": "4.6.2",
-    "lodash.unescape": "4.0.1",
     "tmp": "0.2.1"
+  },
+  "devDependencies": {
+    "prettier": "2.4.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -19,6 +24,30 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+cheerio-select@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
+  integrity sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==
+  dependencies:
+    css-select "^4.1.3"
+    css-what "^5.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+    domutils "^2.7.0"
+
+cheerio@^1.0.0-rc.10:
+  version "1.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.10.tgz#2ba3dcdfcc26e7956fc1f440e61d51c643379f3e"
+  integrity sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==
+  dependencies:
+    cheerio-select "^1.5.0"
+    dom-serializer "^1.3.2"
+    domhandler "^4.2.0"
+    htmlparser2 "^6.1.0"
+    parse5 "^6.0.1"
+    parse5-htmlparser2-tree-adapter "^6.0.1"
+    tslib "^2.2.0"
 
 commander@^2.19.0:
   version "2.20.3"
@@ -38,6 +67,52 @@ config-chain@^1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+css-select@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.1.3.tgz#a70440f70317f2669118ad74ff105e65849c7067"
+  integrity sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^5.0.0"
+    domhandler "^4.2.0"
+    domutils "^2.6.0"
+    nth-check "^2.0.0"
+
+css-what@^5.0.0, css-what@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.1.0.tgz#3f7b707aadf633baf62c2ceb8579b545bb40f7fe"
+  integrity sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==
+
+dom-serializer@^1.0.1, dom-serializer@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
+
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+
+domhandler@^4.0.0, domhandler@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.2.tgz#e825d721d19a86b8c201a35264e226c678ee755f"
+  integrity sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==
+  dependencies:
+    domelementtype "^2.2.0"
+
+domutils@^2.5.2, domutils@^2.6.0, domutils@^2.7.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+  dependencies:
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
+
 editorconfig@^0.15.3:
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-0.15.3.tgz#bef84c4e75fb8dcb0ce5cee8efd51c15999befc5"
@@ -47,6 +122,11 @@ editorconfig@^0.15.3:
     lru-cache "^4.1.5"
     semver "^5.6.0"
     sigmund "^1.0.1"
+
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -64,6 +144,16 @@ glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+htmlparser2@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
+  integrity sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^4.0.0"
+    domutils "^2.5.2"
+    entities "^2.0.0"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -98,11 +188,6 @@ lodash.merge@4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.unescape@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
-  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-
 lru-cache@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -125,6 +210,13 @@ nopt@^5.0.0:
   dependencies:
     abbrev "1"
 
+nth-check@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.0.1.tgz#2efe162f5c3da06a28959fbd3db75dbeea9f0fc2"
+  integrity sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==
+  dependencies:
+    boolbase "^1.0.0"
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -132,10 +224,27 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
+parse5-htmlparser2-tree-adapter@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz#2cdf9ad823321140370d4dbf5d3e92c7c8ddc6e6"
+  integrity sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==
+  dependencies:
+    parse5 "^6.0.1"
+
+parse5@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
+  integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
+prettier@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -170,6 +279,11 @@ tmp@0.2.1:
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
     rimraf "^3.0.0"
+
+tslib@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,15 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
+fs-extra@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
+  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -144,6 +153,11 @@ glob@^7.1.3:
     minimatch "^3.0.4"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -182,6 +196,15 @@ js-beautify@1.14.0:
     editorconfig "^0.15.3"
     glob "^7.1.3"
     nopt "^5.0.0"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 lodash.merge@4.6.2:
   version "4.6.2"
@@ -284,6 +307,11 @@ tslib@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 wrappy@1:
   version "1.0.2"


### PR DESCRIPTION
This PR is a continuation of the work started in the `feature/hugo-errorf-assertion` branch by @manixate.

List of all the changes:

# Major
- Introduced an `expect` shortcode for supporting `errorf` assertions
- Removed support for Hugo before v0.62.0 (because of the usage of `warnf`)
- Updated README.md

# Minor
- Updated `package.json`: next version should be 1.1.0
- Removed not used dependency: `lodash.unescape`
- Always delete the `.output` directory before running the tests
- Introduced a `JEST_HUGO_DEBUG` env variable
- Added Prettier, a `yarn format` command, and a "prettier.yaml" workflow
- Added a workflow for automatically checking broken links in README.md
- Enabled GitHub actions/workflows for all branches
- Added Hugo `latest` to the test matrix