### PR TITLE
Update error comparison logic with newer versions of Hugo 

### DIFF
--- a/jest/setup.js
+++ b/jest/setup.js
@@ -123,8 +123,8 @@ module.exports = async (globalConfig) => {
         }
         if (logDetail.level === "WARN") {
           group.expected = logDetail.log
-           const actualError = detail.find((d) => d.level === "ERROR" && d.log === logDetail.log.split('|')[1])
-          if(actualError != null && Object.keys(actualError).length > 0){
+          const actualError = detail.find((d) => d.level === "ERROR" && d.log === logDetail.log.split("|")[1])
+          if (actualError != null && Object.keys(actualError).length > 0) {
             group.actual = actualError.log
           }
 

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -123,9 +123,9 @@ module.exports = async (globalConfig) => {
         }
         if (logDetail.level === "WARN") {
           group.expected = logDetail.log
-          if (index < detail.length - 1 && detail[index + 1].level === "ERROR") {
-            group.actual = detail[index + 1].log
-            index++
+           const actualError = detail.find((d) => d.level === "ERROR" && d.log === logDetail.log.split('|')[1])
+          if(actualError != null && Object.keys(actualError).length > 0){
+            group.actual = actualError.log
           }
 
           expectedErrorGroups.push(group)

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -73,8 +73,8 @@ function generateTestCases(testPath, errors) {
       const actual = (errors.find((e) => e.expected.startsWith(`${errorId}|`)) || {}).actual
       if (!actual) {
         // No error raised
-        generatedTestCases.push(
-          [`it ('${testTitle}', () => {`, `  throw new Error('No error raised. Was expecting: "${expected}"');`, "})"].join("\n")
+          generatedTestCases.push(
+            [`it ('${testTitle}', () => {`, `  throw new Error(\`No error raised. Was expecting: "${expected}"\`);`, "})"].join("\n")
         )
       } else {
         // Compare errors

--- a/jest/transform.js
+++ b/jest/transform.js
@@ -73,8 +73,8 @@ function generateTestCases(testPath, errors) {
       const actual = (errors.find((e) => e.expected.startsWith(`${errorId}|`)) || {}).actual
       if (!actual) {
         // No error raised
-          generatedTestCases.push(
-            [`it ('${testTitle}', () => {`, `  throw new Error(\`No error raised. Was expecting: "${expected}"\`);`, "})"].join("\n")
+        generatedTestCases.push(
+          [`it ('${testTitle}', () => {`, `  throw new Error(\`No error raised. Was expecting: "${expected}"\`);`, "})"].join("\n")
         )
       } else {
         // Compare errors


### PR DESCRIPTION
### Minor

- With the updated versions of Hugo ( currently on 0.111.3 ) the error logging has been updated. The earlier code used to reference the errors based on the index needs to be updated as there are unwanted logs between the `WARN` from the expect shortcode and the `ERROR` log from Hugo.
- To fix this we now fetch the actual error based on the id from the expect shortcode rather than relying on the index.
- Also added a template literal to fix error while logging error message when the actual error is null. 