### PR TITLE
Updates to support latest Hugo versions and error logs

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -18,7 +18,7 @@ jobs:
           # - windows-latest # uncomment when this is fixed: https://github.com/peaceiris/actions-hugo/issues/608
           # - macos-latest # uncomment when this is fixed: https://github.com/peaceiris/actions-hugo/issues/605
         hugo:
-          - 0.62.0
+          - 0.100.0
           - latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Tests are written in a _tests_ directory in files having the _.md_ extension.
 
 1. Jest 24+
 2. NodeJS 8+
-3. Hugo >= [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.62.0)
+3. Hugo >= [v0.100.0](https://github.com/gohugoio/hugo/releases/tag/v0.100.0)
 
 ## Usage
 
@@ -91,7 +91,7 @@ You can provide your own Hugo config by creating a `jest-hugo.config.json` file 
 4. Run `npm install` or `yarn install`
 5. Run tests using `npm run jest` or `yarn jest`
 
-The demo was tested with Hugo [v0.62.0](https://github.com/gohugoio/hugo/releases/tag/v0.55.0) and the [latest](https://github.com/gohugoio/hugo/releases/latest) version.
+The demo was tested with Hugo [v0.100.0](https://github.com/gohugoio/hugo/releases/tag/v0.100.0) and the [latest](https://github.com/gohugoio/hugo/releases/latest) version.
 
 ## Known Limitations
 

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -48,13 +48,14 @@ const getJestHugoConfig = (rootDir) => {
 
 const extractInfoFromLog = (logLine) => {
   // Each log line is of format:
-  // <level> <YYYY/MM/DD> <HH:MM:SS> <filename>: <log line>
+  // <level> <filename>: <log line>
   // Example:
-  // ERROR 2021/09/23 13:08:34 shortcodes/file.md: Error here
-  const logSplit = logLine.split(" ")
+  // WARN  shortcodes/file.md: Error here
+
+  const logSplit = logLine.split(/\s+/g)
   const level = logSplit[0]
-  const filename = logSplit[3].replace(":", "")
-  const log = logSplit.slice(4).join(" ")
+  const filename = logSplit[1].replace(":", "")
+  const log = logSplit.slice(2).join(" ")
 
   return {
     level: level,
@@ -88,14 +89,14 @@ module.exports = async (globalConfig) => {
       cwd: testDir
     })
   } catch (error) {
-    if (error.stderr && !error.stdout.includes("ERROR")) {
+    if (!error.stderr.includes("ERROR")) {
       // stderr represent errors
       // stdout will not have "ERROR" string if the errors are during build process e.g parsing failed.
       throw error
     }
 
     // Parse stdout that contains errors caused by 'errorf' prefixed by "ERROR" or "WARN"
-    const groupedLogByFilename = error.stdout
+    const groupedLogByFilename = error.stderr
       .replace("Building sites … ", "")
       .replace("Start building sites … ", "")
       .split("\n")

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -73,7 +73,7 @@ const extractInfoFromLog = (logLine, isOlderVersion) => {
 }
 
 /**
- * parse the hugo version string and return the numbers
+ * Parse the hugo version string and return the numbers
  * Hugo version is returned in string example hugo vX.xxx.x-xxx
  * This function returns it as an array of Number [X,xxx,x]
  */

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -132,14 +132,13 @@ module.exports = async (globalConfig) => {
       cwd: testDir
     })
   } catch (error) {
+    const errorLog = isOlderVersion ? error.stdout : error.stderr
     // if for older versions stdout doesn't contain the expected error or for newer version stderr doesn't contain expected error
     // then there's error during the build process and we just simply throw that error
-    const hasErrorLog = isOlderVersion ? error.stdout?.includes("ERROR") : error.stderr?.includes("ERROR")
+    const hasErrorLog = errorLog?.includes("ERROR")
     if (!hasErrorLog) {
       throw error
     }
-
-    const errorLog = isOlderVersion ? error.stdout : error.stderr
 
     // Parse error log that contains errors caused by 'errorf' prefixed by "ERROR" or "WARN"
     const groupedLogByFilename = errorLog


### PR DESCRIPTION
This PR helps modify our code to support updated error logs for newer Hugo versions.
TLDR; As a part of this [PR](https://github.com/gohugoio/hugo/pull/13138/) in Hugo, all logging (info, warn, error) are now logged to stderr and stdout is reserved for program output.
This requires us to modify our approach for checking the error logs and supporting other versions of Hugo as well.